### PR TITLE
Add stream-based CSV export to CsvService

### DIFF
--- a/CheapHelpers.Services/DataExchange/Csv/CsvService.cs
+++ b/CheapHelpers.Services/DataExchange/Csv/CsvService.cs
@@ -62,14 +62,57 @@ public class CsvService : ICsvService
     }
 
     /// <summary>
+    /// Writes a collection of records to a stream as CSV. Caller owns the stream.
+    /// </summary>
+    public async Task ExportToStreamAsync<T>(Stream stream, IEnumerable<T> records, string? culture = null, string? delimiter = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(records);
+
+        try
+        {
+            var writer = new StreamWriter(stream, leaveOpen: true);
+            await using (writer.ConfigureAwait(false))
+            {
+                var config = CreateCsvConfiguration(culture, delimiter);
+                var csvWriter = new CsvWriter(writer, config);
+                await using (csvWriter.ConfigureAwait(false))
+                {
+                    await csvWriter.WriteRecordsAsync(records);
+                }
+            }
+
+            Debug.WriteLine($"Successfully exported CSV to stream");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to export CSV to stream: {ex.Message}");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Exports a collection of records to a CSV byte array. Convenience wrapper
+    /// around <see cref="ExportToStreamAsync{T}"/> using a MemoryStream.
+    /// </summary>
+    public async Task<byte[]> ExportToBytesAsync<T>(IEnumerable<T> records, string? culture = null, string? delimiter = null)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+
+        using var memory = new MemoryStream();
+        await ExportToStreamAsync(memory, records, culture, delimiter);
+        return memory.ToArray();
+    }
+
+    /// <summary>
     /// Creates the CSV configuration with default settings
     /// </summary>
-    private static CsvConfiguration CreateCsvConfiguration()
+    private static CsvConfiguration CreateCsvConfiguration(string? culture = null, string? delimiter = null)
     {
-        var culture = CultureInfo.CreateSpecificCulture(DefaultCulture);
-        return new CsvConfiguration(culture)
+        var ci = CultureInfo.CreateSpecificCulture(culture ?? DefaultCulture);
+        return new CsvConfiguration(ci)
         {
-            Delimiter = DefaultDelimiter
+            Delimiter = delimiter ?? DefaultDelimiter
         };
     }
 }

--- a/CheapHelpers.Services/DataExchange/Csv/ICsvService.cs
+++ b/CheapHelpers.Services/DataExchange/Csv/ICsvService.cs
@@ -5,5 +5,7 @@
         Task Export(string filePath, IEnumerable<string> list);
         Task Export(string filePath, IEnumerable<dynamic> list);
 
+        Task ExportToStreamAsync<T>(Stream stream, IEnumerable<T> records, string? culture = null, string? delimiter = null);
+        Task<byte[]> ExportToBytesAsync<T>(IEnumerable<T> records, string? culture = null, string? delimiter = null);
     }
 }


### PR DESCRIPTION
Stream and byte[] overloads for HTTP download scenarios. Existing file methods unchanged.