### PR TITLE
remove legacy Microsoft.AspNetCore.Identity 2.3.9 reference

### DIFF
--- a/CheapHelpers.EF/CheapHelpers.EF.csproj
+++ b/CheapHelpers.EF/CheapHelpers.EF.csproj
@@ -32,7 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 <!--
   TODO.md — CheapHelpers project work tracker
-  Last updated: 2026-04-16 (legacy Identity 2.3.9 removal blocking Voltiq CI)
+  Last updated: 2026-04-17 (legacy Identity 2.3.9 removed — NU1903 cleared)
 
   RULES FOR AI AGENTS:
   - Update the "Last updated" date above whenever you modify this file
@@ -29,12 +29,9 @@
 
 ## Blocking
 
-- [ ] (2026-04-16) Remove legacy `Microsoft.AspNetCore.Identity 2.3.9` reference from `CheapHelpers.EF.csproj` [voltiq-dep] [audit]
-  - Line 35 is dead weight — line 36 already references the modern `Microsoft.AspNetCore.Identity.EntityFrameworkCore 10.0.5` which provides all needed types via the same namespace
-  - Legacy 2.x package drags in `Microsoft.AspNetCore.DataProtection 2.3.0` → `System.Security.Cryptography.Xml 8.0.2` which has two high-severity CVEs (GHSA-w3x6-4m5h-cxqf, GHSA-37gx-xxp4-5rgx)
-  - Blocks Voltiq CI: `TreatWarningsAsErrors` + `NU1903` fails every build
-  - Fix: delete the `Microsoft.AspNetCore.Identity 2.3.9` PackageReference, bump CheapHelpers to 3.4.4, publish
-  - Verify: `dotnet nuget why CheapHelpers.EF.csproj System.Security.Cryptography.Xml` should return "no dependency"
+- [x] (2026-04-16 → 2026-04-17) Remove legacy `Microsoft.AspNetCore.Identity 2.3.9` reference from `CheapHelpers.EF.csproj` [voltiq-dep] [audit]
+  - Deleted the 2.3.9 PackageReference; added `<FrameworkReference Include="Microsoft.AspNetCore.App" />` so `IServiceCollection.AddIdentity<,>` resolves from the shared framework instead of the legacy NuGet
+  - Verified via `dotnet nuget why`: `System.Security.Cryptography.Xml` and `Microsoft.AspNetCore.DataProtection` no longer transitively referenced
 
 - [x] (2026-03-30 → 2026-03-30) `UserService<TUser>` should resolve `IDbContextFactory` for derived context types [voltiq-dep]
   - Added `TContext` generic parameter to `UserRepo<TUser, TContext>`, `UserService<TUser, TContext>`, `CheapAccountController<TUser, TContext>`


### PR DESCRIPTION
Legacy 2.x package was transitively dragging in System.Security.Cryptography.Xml 8.0.2 (two high-severity CVEs), failing NU1903 downstream. Modern Microsoft.AspNetCore.Identity.EntityFrameworkCore 10.0.6 already provides the same namespace; added a FrameworkReference to Microsoft.AspNetCore.App so AddIdentity<,> still resolves.