### PR TITLE
Move Identity registration to CheapHelpers.Blazor

### DIFF
--- a/CheapHelpers.Blazor/Extensions/CheapContextBuilderIdentityExtensions.cs
+++ b/CheapHelpers.Blazor/Extensions/CheapContextBuilderIdentityExtensions.cs
@@ -3,7 +3,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 // Deliberately in the EF namespace: these used to be instance methods on CheapContextBuilder,
-// so existing call sites keep compiling without a new using directive.
+// so no new using directive is needed. Parameterless AddIdentity() call sites keep compiling
+// (all type args infer from the receiver). BREAKING: the role overload changed from
+// AddIdentity<TRole>() to AddIdentity<TUser, TContext, TRole>() — C# cannot partially infer
+// generic arguments on extension methods.
 namespace CheapHelpers.EF.Infrastructure
 {
     /// <summary>

--- a/CheapHelpers.Blazor/Extensions/CheapContextBuilderIdentityExtensions.cs
+++ b/CheapHelpers.Blazor/Extensions/CheapContextBuilderIdentityExtensions.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+// Deliberately in the EF namespace: these used to be instance methods on CheapContextBuilder,
+// so existing call sites keep compiling without a new using directive.
+namespace CheapHelpers.EF.Infrastructure
+{
+    /// <summary>
+    /// Identity registration for <see cref="CheapContextBuilder{TUser, TContext}"/>.
+    /// Lives in CheapHelpers.Blazor because <c>IServiceCollection.AddIdentity</c> requires the
+    /// ASP.NET Core shared framework, which CheapHelpers.EF avoids to stay Android-consumable.
+    /// </summary>
+    public static class CheapContextBuilderIdentityExtensions
+    {
+        /// <summary>
+        /// Adds Identity services with CheapContext defaults.
+        /// Identity stores are registered against the actual context type (<typeparamref name="TContext"/>),
+        /// not the base <c>CheapContext</c>, ensuring correct DI resolution at all context levels.
+        /// </summary>
+        public static IdentityBuilder AddIdentity<TUser, TContext, TRole>(
+            this CheapContextBuilder<TUser, TContext> builder,
+            Action<IdentityOptions>? configureOptions = null)
+            where TUser : IdentityUser
+            where TContext : DbContext
+            where TRole : IdentityRole
+        {
+            var identityBuilder = builder.Services.AddIdentity<TUser, TRole>(identityOptions =>
+            {
+                identityOptions.Password = builder.ContextOptions.Identity.Password;
+                identityOptions.SignIn = builder.ContextOptions.Identity.SignIn;
+                identityOptions.Lockout = builder.ContextOptions.Identity.Lockout;
+                identityOptions.User = builder.ContextOptions.Identity.User;
+                identityOptions.Stores = builder.ContextOptions.Identity.Stores;
+                identityOptions.Tokens = builder.ContextOptions.Identity.Tokens;
+                identityOptions.ClaimsIdentity = builder.ContextOptions.Identity.ClaimsIdentity;
+
+                configureOptions?.Invoke(identityOptions);
+            })
+            .AddEntityFrameworkStores<TContext>()
+            .AddDefaultTokenProviders();
+
+            return identityBuilder;
+        }
+
+        /// <summary>
+        /// Adds Identity services with IdentityRole and CheapContext defaults.
+        /// </summary>
+        public static IdentityBuilder AddIdentity<TUser, TContext>(
+            this CheapContextBuilder<TUser, TContext> builder,
+            Action<IdentityOptions>? configureOptions = null)
+            where TUser : IdentityUser
+            where TContext : DbContext
+        {
+            return builder.AddIdentity<TUser, TContext, IdentityRole>(configureOptions);
+        }
+    }
+}

--- a/CheapHelpers.EF/CheapHelpers.EF.csproj
+++ b/CheapHelpers.EF/CheapHelpers.EF.csproj
@@ -32,10 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <!-- No FrameworkReference here on purpose: Microsoft.AspNetCore.App has no Android runtime
+         pack (NETSDK1082), and keeping it out lets MAUI apps consume this package.
+         Framework-dependent Identity wiring lives in CheapHelpers.Blazor. -->
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/CheapHelpers.EF/Infrastructure/CheapContextBuilder.cs
+++ b/CheapHelpers.EF/Infrastructure/CheapContextBuilder.cs
@@ -7,6 +7,9 @@ namespace CheapHelpers.EF.Infrastructure
     /// <summary>
     /// Builder for fluent CheapContext configuration.
     /// Tracks the concrete context type so Identity stores are registered against the correct level.
+    /// Identity registration (<c>AddIdentity</c>) lives in CheapHelpers.Blazor — it needs the
+    /// ASP.NET Core shared framework, which this package deliberately avoids so it stays
+    /// consumable from MAUI/Android targets.
     /// </summary>
     public class CheapContextBuilder<TUser, TContext>
         where TUser : IdentityUser
@@ -22,43 +25,14 @@ namespace CheapHelpers.EF.Infrastructure
         }
 
         /// <summary>
-        /// Adds Identity services with CheapContext defaults.
-        /// Identity stores are registered against the actual context type (<typeparamref name="TContext"/>),
-        /// not the base <c>CheapContext</c>, ensuring correct DI resolution at all context levels.
-        /// </summary>
-        public IdentityBuilder AddIdentity<TRole>(Action<IdentityOptions>? configureOptions = null)
-            where TRole : IdentityRole
-        {
-            var identityBuilder = _services.AddIdentity<TUser, TRole>(identityOptions =>
-            {
-                identityOptions.Password = _contextOptions.Identity.Password;
-                identityOptions.SignIn = _contextOptions.Identity.SignIn;
-                identityOptions.Lockout = _contextOptions.Identity.Lockout;
-                identityOptions.User = _contextOptions.Identity.User;
-                identityOptions.Stores = _contextOptions.Identity.Stores;
-                identityOptions.Tokens = _contextOptions.Identity.Tokens;
-                identityOptions.ClaimsIdentity = _contextOptions.Identity.ClaimsIdentity;
-
-                configureOptions?.Invoke(identityOptions);
-            })
-            .AddEntityFrameworkStores<TContext>()
-            .AddDefaultTokenProviders();
-
-            return identityBuilder;
-        }
-
-        /// <summary>
-        /// Adds Identity services with IdentityRole and CheapContext defaults.
-        /// </summary>
-        public IdentityBuilder AddIdentity(Action<IdentityOptions>? configureOptions = null)
-        {
-            return AddIdentity<IdentityRole>(configureOptions);
-        }
-
-        /// <summary>
         /// Access to the underlying service collection for additional configuration.
         /// </summary>
         public IServiceCollection Services => _services;
+
+        /// <summary>
+        /// The context options this builder was created with, so extensions can apply the configured defaults.
+        /// </summary>
+        public CheapContextOptions ContextOptions => _contextOptions;
     }
 
     /// <summary>


### PR DESCRIPTION
Drops the Microsoft.AspNetCore.App framework reference from CheapHelpers.EF so the package can be consumed from MAUI Android apps (NETSDK1082). The AddIdentity builder methods move to CheapHelpers.Blazor as extension methods in the same namespace. Parameterless AddIdentity() stays source-compatible; the role overload is now AddIdentity<TUser, TContext, TRole>() since extension methods can't partially infer generics.