### PR TITLE
Add browser web push to Azure Notification Hub backend

### DIFF
--- a/CheapHelpers.Blazor/Hybrid/Extensions/BlazorHybridServiceExtensions.cs
+++ b/CheapHelpers.Blazor/Hybrid/Extensions/BlazorHybridServiceExtensions.cs
@@ -149,12 +149,14 @@ public class PushNotificationOptions
     /// </summary>
     /// <param name="connectionString">Azure Notification Hub connection string (from Azure Portal → Access Policies).</param>
     /// <param name="hubName">Name of the Notification Hub.</param>
-    public void UseAzureNotificationHubs(string connectionString, string hubName)
+    /// <param name="enableBrowserPush">Enable Browser (Web Push) installations and sends via the NH REST API. Requires VAPID credentials on the hub's Browser (Web Push) blade.</param>
+    public void UseAzureNotificationHubs(string connectionString, string hubName, bool enableBrowserPush = false)
     {
         BackendFactory = sp => new AzureNotificationHubBackend(
             connectionString,
             hubName,
-            sp.GetService<ILogger<AzureNotificationHubBackend>>());
+            sp.GetService<ILogger<AzureNotificationHubBackend>>(),
+            enableBrowserPush);
     }
 
     /// <summary>

--- a/CheapHelpers.Blazor/Hybrid/Models/DeviceInstallation.cs
+++ b/CheapHelpers.Blazor/Hybrid/Models/DeviceInstallation.cs
@@ -31,4 +31,11 @@ public class DeviceInstallation
     /// </summary>
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = [];
+
+    /// <summary>
+    /// Web Push subscription triplet — required when <see cref="Platform"/> is "webpush"/"browser",
+    /// ignored otherwise. <see cref="PushChannel"/> is not used for browser installations.
+    /// </summary>
+    [JsonPropertyName("browserSubscription")]
+    public WebPushSubscription? BrowserSubscription { get; set; }
 }

--- a/CheapHelpers.Blazor/Hybrid/Models/WebPushSubscription.cs
+++ b/CheapHelpers.Blazor/Hybrid/Models/WebPushSubscription.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace CheapHelpers.Blazor.Hybrid.Models;
+
+/// <summary>
+/// Browser Web Push subscription triplet as produced by <c>PushManager.subscribe()</c>.
+/// Property names match the Azure Notification Hubs browser installation pushChannel contract.
+/// </summary>
+public class WebPushSubscription
+{
+    /// <summary>
+    /// Push service endpoint URL from the browser subscription
+    /// </summary>
+    [JsonPropertyName("endpoint")]
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client public key (p256dh) from the browser subscription
+    /// </summary>
+    [JsonPropertyName("p256dh")]
+    public string P256dh { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Auth secret from the browser subscription
+    /// </summary>
+    [JsonPropertyName("auth")]
+    public string Auth { get; set; } = string.Empty;
+}

--- a/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
+++ b/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
@@ -2,22 +2,42 @@ using CheapHelpers.Blazor.Hybrid.Abstractions;
 using CheapHelpers.Blazor.Hybrid.Models;
 using Microsoft.Azure.NotificationHubs;
 using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 
 namespace CheapHelpers.Blazor.Hybrid.Notifications.Backends;
 
 /// <summary>
 /// Azure Notification Hubs implementation of <see cref="IPushNotificationBackend"/>.
 /// Manages device installations and sends push notifications via Azure NH.
+/// <para>
+/// Browser (Web Push) support: the released Microsoft.Azure.NotificationHubs SDK (4.2.0) has no
+/// Browser platform, so browser installations and sends go through the NH REST API directly
+/// (api-version 2020-06). Opt in via <paramref name="enableBrowserPush"/> — requires VAPID
+/// credentials configured on the hub's Browser (Web Push) blade.
+/// </para>
 /// </summary>
 public class AzureNotificationHubBackend(
     string connectionString,
     string hubName,
-    ILogger<AzureNotificationHubBackend>? logger = null) : IPushNotificationBackend
+    ILogger<AzureNotificationHubBackend>? logger = null,
+    bool enableBrowserPush = false) : IPushNotificationBackend
 {
+    private const string RestApiVersion = "2020-06";
+    private static readonly HttpClient _httpClient = new();
+
     private readonly NotificationHubClient _hubClient = NotificationHubClient.CreateClientFromConnectionString(connectionString, hubName);
 
     public async Task<bool> RegisterDeviceAsync(DeviceInstallation device)
     {
+        if (IsBrowserPlatform(device.Platform))
+        {
+            return await RegisterBrowserDeviceAsync(device);
+        }
+
         try
         {
             var installation = new Installation
@@ -121,14 +141,18 @@ public class AzureNotificationHubBackend(
                 outcome = await _hubClient.SendNotificationAsync(notification);
             }
 
+            // Browser installations are invisible to the SDK send above — fan out via REST as well
+            var browserOk = !enableBrowserPush || await SendBrowserNotificationAsync(payload);
+
             logger?.LogInformation("Notification sent: {Success} success, {Failure} failure",
                 outcome.Success, outcome.Failure);
 
             return new SendNotificationResult
             {
-                Success = outcome.Failure == 0,
+                Success = outcome.Failure == 0 && browserOk,
                 SuccessCount = (int)outcome.Success,
                 FailureCount = (int)outcome.Failure,
+                ErrorMessage = browserOk ? null : "Browser push send failed — see logs",
             };
         }
         catch (Exception ex)
@@ -153,12 +177,148 @@ public class AzureNotificationHubBackend(
         });
     }
 
+    #region Browser (Web Push) via REST — no SDK support in Microsoft.Azure.NotificationHubs 4.2.0
+
+    private static bool IsBrowserPlatform(string platform) =>
+        platform.ToLowerInvariant() is "webpush" or "browser";
+
+    private async Task<bool> RegisterBrowserDeviceAsync(DeviceInstallation device)
+    {
+        if (!enableBrowserPush)
+        {
+            logger?.LogError("Browser installation {InstallationId} rejected — enable browser push on UseAzureNotificationHubs and configure VAPID credentials on the hub", device.InstallationId);
+            return false;
+        }
+
+        if (device.BrowserSubscription is not { Endpoint.Length: > 0, P256dh.Length: > 0, Auth.Length: > 0 })
+        {
+            logger?.LogError("Browser installation {InstallationId} rejected — BrowserSubscription requires endpoint, p256dh and auth", device.InstallationId);
+            return false;
+        }
+
+        try
+        {
+            var installationJson = JsonSerializer.Serialize(new
+            {
+                installationId = device.InstallationId,
+                platform = "browser",
+                pushChannel = device.BrowserSubscription,
+                tags = device.Tags,
+            });
+
+            using var request = CreateRestRequest(HttpMethod.Put, $"installations/{Uri.EscapeDataString(device.InstallationId)}");
+            request.Content = new StringContent(installationJson, Encoding.UTF8, "application/json");
+
+            using var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                logger?.LogError("Failed to register browser device {InstallationId}: {StatusCode} {Body}", device.InstallationId, response.StatusCode, responseBody);
+                return false;
+            }
+
+            logger?.LogInformation("Registered browser device {InstallationId}", device.InstallationId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Failed to register browser device {InstallationId}", device.InstallationId);
+            return false;
+        }
+    }
+
+    private async Task<bool> SendBrowserNotificationAsync(NotificationPayload payload)
+    {
+        try
+        {
+            var bodyFields = new Dictionary<string, object> { ["title"] = payload.Title, ["body"] = payload.Body };
+            if (payload.Data is { Count: > 0 })
+            {
+                bodyFields["data"] = payload.Data;
+            }
+
+            using var request = CreateRestRequest(HttpMethod.Post, "messages/");
+            request.Content = new StringContent(JsonSerializer.Serialize(bodyFields), Encoding.UTF8, "application/json");
+            request.Headers.Add("ServiceBusNotification-Format", "browser");
+
+            var tagExpression = payload switch
+            {
+                { Tags.Count: > 0 } => string.Join(" || ", payload.Tags),
+                { DeviceIds.Count: > 0 } => string.Join(" || ", payload.DeviceIds.Select(id => $"$InstallationId:{{{id}}}")),
+                _ => null,
+            };
+            if (tagExpression is not null)
+            {
+                request.Headers.Add("ServiceBusNotification-Tags", tagExpression);
+            }
+
+            using var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                logger?.LogError("Browser push send failed: {StatusCode} {Body}", response.StatusCode, responseBody);
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Browser push send failed");
+            return false;
+        }
+    }
+
+    private HttpRequestMessage CreateRestRequest(HttpMethod method, string relativePath)
+    {
+        var (endpoint, keyName, key) = ParseConnectionString(connectionString);
+        var resourceUri = $"{endpoint}{hubName}/{relativePath}";
+        var request = new HttpRequestMessage(method, $"{resourceUri}?api-version={RestApiVersion}");
+        request.Headers.TryAddWithoutValidation("Authorization", CreateSasToken(resourceUri, keyName, key));
+        return request;
+    }
+
+    private static (string Endpoint, string KeyName, string Key) ParseConnectionString(string connectionString)
+    {
+        string? endpoint = null, keyName = null, key = null;
+        foreach (var part in connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separatorIndex = part.IndexOf('=');
+            if (separatorIndex < 0) continue;
+            var name = part[..separatorIndex].Trim();
+            var value = part[(separatorIndex + 1)..].Trim();
+            switch (name.ToLowerInvariant())
+            {
+                case "endpoint": endpoint = value.Replace("sb://", "https://"); break;
+                case "sharedaccesskeyname": keyName = value; break;
+                case "sharedaccesskey": key = value; break;
+            }
+        }
+
+        if (endpoint is null || keyName is null || key is null)
+        {
+            throw new ArgumentException("Connection string must contain Endpoint, SharedAccessKeyName and SharedAccessKey");
+        }
+
+        return (endpoint.EndsWith('/') ? endpoint : endpoint + "/", keyName, key);
+    }
+
+    private static string CreateSasToken(string resourceUri, string keyName, string key)
+    {
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeSeconds();
+        var stringToSign = $"{Uri.EscapeDataString(resourceUri)}\n{expiry}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key));
+        var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(stringToSign)));
+        return $"SharedAccessSignature sr={Uri.EscapeDataString(resourceUri)}&sig={Uri.EscapeDataString(signature)}&se={expiry}&skn={keyName}";
+    }
+
+    #endregion
+
     private static NotificationPlatform ParsePlatform(string platform) => platform.ToLowerInvariant() switch
     {
         "fcm" or "fcmv1" or "android" => NotificationPlatform.FcmV1,
         "apns" or "ios" => NotificationPlatform.Apns,
         "wns" or "windows" => NotificationPlatform.Wns,
-        "webpush" or "browser" => NotificationPlatform.Wns, // Web push via WNS for now
         _ => throw new ArgumentException($"Unknown platform: {platform}", nameof(platform)),
     };
 

--- a/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
+++ b/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
@@ -68,6 +68,17 @@ public class AzureNotificationHubBackend(
         }
         catch (Exception ex)
         {
+            // The SDK can't deserialize browser installations (no Browser value in its
+            // NotificationPlatform enum) — fall back to the REST installation GET
+            if (enableBrowserPush)
+            {
+                var browserDevice = await GetBrowserDeviceAsync(deviceId);
+                if (browserDevice is not null)
+                {
+                    return browserDevice;
+                }
+            }
+
             logger?.LogWarning(ex, "Failed to get device {DeviceId}", deviceId);
             return null;
         }
@@ -224,6 +235,45 @@ public class AzureNotificationHubBackend(
         {
             logger?.LogError(ex, "Failed to register browser device {InstallationId}", device.InstallationId);
             return false;
+        }
+    }
+
+    private async Task<DeviceInfo?> GetBrowserDeviceAsync(string deviceId)
+    {
+        try
+        {
+            using var request = CreateRestRequest(HttpMethod.Get, $"installations/{Uri.EscapeDataString(deviceId)}");
+            using var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            using var installationDoc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var root = installationDoc.RootElement;
+            if (root.GetProperty("platform").GetString() is not ("browser" or "Browser"))
+            {
+                return null;
+            }
+
+            return new DeviceInfo
+            {
+                DeviceId = deviceId,
+                Platform = "browser",
+                PushToken = root.TryGetProperty("pushChannel", out var channel) && channel.TryGetProperty("endpoint", out var endpoint)
+                    ? endpoint.GetString() ?? string.Empty
+                    : string.Empty,
+                IsActive = true,
+                Tags = root.TryGetProperty("tags", out var tags) && tags.ValueKind == JsonValueKind.Array
+                    ? [.. tags.EnumerateArray().Select(t => t.GetString() ?? string.Empty)]
+                    : [],
+                LastUpdated = DateTime.UtcNow,
+            };
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to get browser device {DeviceId} via REST", deviceId);
+            return null;
         }
     }
 

--- a/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
+++ b/CheapHelpers.Blazor/Hybrid/Notifications/Backends/AzureNotificationHubBackend.cs
@@ -227,6 +227,9 @@ public class AzureNotificationHubBackend(
         }
     }
 
+    // NH audience sends are queued: the POST returns 201 on acceptance regardless of how many
+    // installations match, so zero browser subscribers never fails the send — only real HTTP
+    // errors (bad SAS, browser/VAPID credentials missing on the hub) return false here.
     private async Task<bool> SendBrowserNotificationAsync(NotificationPayload payload)
     {
         try


### PR DESCRIPTION
The released NH SDK has no Browser platform, so browser installations and sends go through the NH REST API with SAS auth. Opt-in via enableBrowserPush on UseAzureNotificationHubs; existing platforms unchanged.